### PR TITLE
Initial pass to lumberjack server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+main
+go-lumber
 # Compiled Object files, Static and Dynamic libs (Shared Objects)
 *.o
 *.a

--- a/lumberjack/lumberjack.go
+++ b/lumberjack/lumberjack.go
@@ -1,0 +1,205 @@
+package lumberjack
+
+import (
+	"compress/zlib"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"time"
+
+	"github.com/elastic/beats/libbeat/common/streambuf"
+)
+
+type Lumberjack struct {
+	net.Listener
+	timeout   time.Duration
+	err       error
+	handshake func(net.Conn)
+}
+
+type Message struct {
+	Code   uint8
+	Size   uint32
+	Seq    uint32
+	Events []*Message
+	Doc    Document
+}
+
+type AckHandler struct {
+	seq    uint32
+	client  net.Conn
+
+}
+
+type Document map[string]interface{}
+
+type Success func(h AckHandler) bool
+
+type Failure func(h AckHandler) bool
+
+type Process func(events []*Message) bool
+
+type Handlers struct {
+	Success   Success
+	Failure   Failure
+	Process   Process
+}
+
+func NewLumberJack(bind string, to time.Duration) (*Lumberjack, error) {
+	tcpListener, err := net.Listen("tcp", bind)
+	if err != nil {
+		return nil, err
+	}
+
+	server := &Lumberjack{Listener: tcpListener, timeout: to}
+	server.handshake = func(client net.Conn) {}
+
+	return server, nil
+}
+
+func AcceptConnections(server *Lumberjack, ha *Handlers) {
+	for {
+		client, err := server.Accept()
+		if err != nil {
+			fmt.Println("failed to accept client: ", err)
+		} else {
+			fmt.Println("Connection established with ", client.RemoteAddr())
+		}
+
+		go run(client, ha)
+	}
+}
+
+func run(client net.Conn, ha *Handlers) {
+	defer client.Close()
+
+	fmt.Println("serve new client")
+
+	var N uint32
+	buf := streambuf.New(nil)
+	for {
+		ackHandler := AckHandler{N, client}
+		msg, err := recvMessage(buf, client)
+		if err != nil {
+			ha.Failure(ackHandler)
+			//fmt.Println("failed to read message from client: ", err)
+			return
+		}
+
+		switch msg.Code {
+		case 'W':
+			N = msg.Size
+		case 'C':
+			events := msg.Events
+			ha.Success(ackHandler)
+			ha.Process(events)
+		}
+
+	}
+}
+
+func recvMessage(buf *streambuf.Buffer, client net.Conn) (*Message, error) {
+	for {
+		msg, err := readMessage(buf)
+		if msg != nil || (err != nil && err != streambuf.ErrNoMoreBytes) {
+			return msg, err
+		}
+
+		buffer := make([]byte, 1024)
+		n, err := client.Read(buffer)
+		if err != nil {
+			return nil, err
+		}
+		buf.Write(buffer[:n])
+	}
+}
+
+func readMessage(buf *streambuf.Buffer) (*Message, error) {
+	if !buf.Avail(2) {
+		return nil, nil
+	}
+	version, _ := buf.ReadNetUint8At(0)
+	if version != '2' {
+		return nil, errors.New("version error")
+	}
+
+	code, _ := buf.ReadNetUint8At(1)
+	switch code {
+	case 'W':
+		if !buf.Avail(6) {
+			return nil, nil
+		}
+		size, _ := buf.ReadNetUint32At(2)
+		buf.Advance(6)
+		err := buf.Err()
+		buf.Reset()
+		return &Message{Code: code, Size: size}, err
+	case 'C':
+		if !buf.Avail(6) {
+			return nil, nil
+		}
+		len, _ := buf.ReadNetUint32At(2)
+
+		if !buf.Avail(int(len) + 6) {
+			return nil, nil
+		}
+		buf.Advance(6)
+
+		tmp, _ := buf.Collect(int(len))
+		buf.Reset()
+
+		dataBuf := streambuf.New(nil)
+		// decompress data
+		decomp, err := zlib.NewReader(streambuf.NewFixed(tmp))
+		if err != nil {
+			return nil, err
+		}
+		// dataBuf.ReadFrom(streambuf.NewFixed(tmp))
+		dataBuf.ReadFrom(decomp)
+		decomp.Close()
+
+		// unpack data
+		dataBuf.Fix()
+		var events []*Message
+		for dataBuf.Len() > 0 {
+			version, _ := dataBuf.ReadNetUint8()
+			if version != '2' {
+				return nil, errors.New("version error 2")
+			}
+
+			code, _ := dataBuf.ReadNetUint8()
+			if code != 'J' {
+				return nil, errors.New("expected json data frame")
+			}
+
+			seq, _ := dataBuf.ReadNetUint32()
+			payloadLen, _ := dataBuf.ReadNetUint32()
+			jsonRaw, _ := dataBuf.Collect(int(payloadLen))
+
+			var doc interface{}
+			err = json.Unmarshal(jsonRaw, &doc)
+			if err != nil {
+				return nil, err
+			}
+
+			events = append(events, &Message{
+				Code: code,
+				Seq:  seq,
+				Doc:  doc.(map[string]interface{}),
+			})
+		}
+
+		return &Message{Code: 'C', Events: events}, nil
+	default:
+		return nil, errors.New("unknown code")
+	}
+}
+
+func SendAck(ack AckHandler) {
+	buf := streambuf.New(nil)
+	buf.WriteByte('2')
+	buf.WriteByte('A')
+	buf.WriteNetUint32(ack.seq)
+	ack.client.Write(buf.Bytes())
+}

--- a/main.go
+++ b/main.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	ljack "github.com/urso/go-lumber/lumberjack"
+	"github.com/elastic/libbeat/logp"
+)
+
+
+//sample implementation of using the lumberjack server
+func main() {
+	tcpBindAddress := "localhost:5044"
+	server, err := ljack.NewLumberJack(tcpBindAddress,  90*time.Second)
+	if err != nil {
+		fmt.Println("failed to create tcp server: ", err)
+		os.Exit(1)
+	}
+	fmt.Println("tcp server up")
+
+	defer server.Close()
+
+	ha := ljack.Handlers{Success: success, Failure: failure, Process: process}
+	ljack.AcceptConnections(server, &ha)
+}
+
+func success (ack ljack.AckHandler) bool {
+	ljack.SendAck(ack)
+	return true;
+}
+
+func failure (ack ljack.AckHandler) bool {
+	logp.Critical("Unable to process incoming packets")
+	return true
+}
+
+func process (events []*ljack.Message) bool {
+	for _, event := range events {
+		fmt.Println(event.Doc)
+	}
+
+	return true;
+}


### PR DESCRIPTION
I have provided a Handler object that has 3 handlers for success, failure and process. These can be implemented based on use case needs. the main.go offers a sample of a bare bones implementation of success failure and processing of events.

TODO:
* split receive and process as two separate workers.
* batch processing 
* improve scalability